### PR TITLE
move config outside init function

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,50 +1,29 @@
 package unilog
 
 import (
-	"os"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-var cfg = zap.Config{
-	Encoding:         "console",
-	Level:            zap.NewAtomicLevelAt(zapcore.DebugLevel),
-	OutputPaths:      []string{"stdout"},
-	ErrorOutputPaths: []string{"stderr"},
-	EncoderConfig: zapcore.EncoderConfig{
-		MessageKey: "message",
+func DefaultConfig() zap.Config{
+	return zap.Config{
+		Encoding:         "console",
+		Level:            zap.NewAtomicLevelAt(zapcore.DebugLevel),
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stderr"},
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey: "message",
 
-		LevelKey:    "level",
-		EncodeLevel: zapcore.CapitalLevelEncoder,
+			LevelKey:    "level",
+			EncodeLevel: zapcore.CapitalLevelEncoder,
 
-		TimeKey:    "time",
-		EncodeTime: zapcore.ISO8601TimeEncoder,
+			TimeKey:    "time",
+			EncodeTime: zapcore.ISO8601TimeEncoder,
 
-		CallerKey:    "caller",
-		EncodeCaller: zapcore.ShortCallerEncoder,
+			CallerKey:    "caller",
+			EncodeCaller: zapcore.ShortCallerEncoder,
 
-		StacktraceKey: "stacktrace",
-	},
-}
-
-// newLogger creates a new instance of zap.Logger and returns a pointer to it
-func newLogger(logPath string) (*zap.Logger, error) {
-	if logPath != "" {
-		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			return nil, err
-		}
-		err = f.Close()
-		if err != nil {
-			return nil, err
-		}
-		cfg.OutputPaths = append(cfg.OutputPaths, logPath)
-		cfg.ErrorOutputPaths = append(cfg.ErrorOutputPaths, logPath)
+			StacktraceKey: "stacktrace",
+		},
 	}
-	logger, err := cfg.Build()
-	if err != nil {
-		return nil, err
-	}
-	return logger, nil
 }

--- a/logger.go
+++ b/logger.go
@@ -10,9 +10,9 @@ import (
 
 var log *zap.Logger
 
-func InitLog(logPath string) {
+func InitLog(cfg zap.Config) {
 	var err error
-	log, err = newLogger(logPath)
+	log, err = cfg.Build()
 	if err != nil {
 		fmt.Println("unable to initialize log")
 		fmt.Println(err)
@@ -22,7 +22,8 @@ func InitLog(logPath string) {
 
 func Logger() *zap.Logger {
 	if log == nil {
-		InitLog("")
+		cfg := DefaultConfig()
+		InitLog(cfg)
 	}
 	return log
 }


### PR DESCRIPTION
InitLog now accepts zap.Config as an argument. Keep default config(used to be "var cfg") as DefaultConfig()